### PR TITLE
Remove poxis dependency, unnecessary with the v6.0 of NodeJS

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -7,7 +7,6 @@ var cp = require('child_process');
 var fs = require('fs');
 var os = require('os');
 var path = require('path');
-var posix = require('posix');
 var sqparse = require('shell-quote').parse;
 var zlib = require('zlib');
 
@@ -381,10 +380,10 @@ module.exports = Class.create({
 		// resolve uid / gid to numbers if required
 		if (!child_opts.uid.toString().match(/^\d+$/)) {
 			try {
-				var user_info = posix.getpwnam( child_opts.uid );
+				var user_info = os.userInfo();
 				child_opts.uid = user_info.uid;
-				child_opts.env.USER = child_opts.env.USERNAME = user_info.name;
-				child_opts.env.HOME = user_info.dir;
+				child_opts.env.USER = child_opts.env.USERNAME = user_info.username;
+				child_opts.env.HOME = user_info.homedir;
 				child_opts.env.SHELL = user_info.shell;
 			}
 			catch (err) {
@@ -400,7 +399,7 @@ module.exports = Class.create({
 		}
 		if (!child_opts.gid.toString().match(/^\d+$/)) {
 			try {
-				var grp_info = posix.getgrnam( child_opts.gid );
+				var grp_info = os.userInfo();
 				child_opts.gid = grp_info.gid;
 			}
 			catch (err) {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
 		"jstimezonedetect": "^1.0.6",
 		"netmask": "^1.0.5",
 		"shell-quote": "^1.4.3",
-		"posix": "^4.0.0",
 		"bcrypt-node": "^0.1.0",
 		"pixl-args": "^1.0.0",
 		"pixl-config": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,14 @@
 {
 	"name": "Cronicle",
-	"version": "0.5.6",
+	"version": "0.5.7",
 	"description": "A simple, distributed task scheduler and runner with a web based UI.",
 	"author": "Joseph Huckaby <jhuckaby@gmail.com>",
 	"homepage": "https://github.com/jhuckaby/Cronicle",
 	"license": "MIT",
 	"main": "lib/main.js",
+	"engines" : { 
+		"node" : ">=6.0" 
+	},
 	"scripts": {
 		"test": "pixl-unit node_modules/pixl-server-storage/test/test.js lib/test.js"
 	},


### PR DESCRIPTION
The problem with the posix dependency is that it depend of a C module, and its compilation on some cloud machine without some rights is not possible.
So now cronicle use native NodeJS calls to get user info.
PS. cronicle is very awesome!