### PR TITLE
Added https header detect to sample configuration

### DIFF
--- a/sample_conf/config.json
+++ b/sample_conf/config.json
@@ -82,7 +82,14 @@
 		"https_cert_file": "conf/ssl.crt",
 		"https_key_file": "conf/ssl.key",
 		"https_force": 0,
-		"https_timeout": 30
+		"https_timeout": 30,
+        "https_header_detect": {
+            "Front-End-Https": "^on$",
+            "X-Url-Scheme": "^https$",
+            "X-Forwarded-Protocol": "^https$",
+            "X-Forwarded-Proto": "^https$",
+            "X-Forwarded-Ssl": "^on$"
+        }
 	},
 	
 	"User": {

--- a/sample_conf/config.json
+++ b/sample_conf/config.json
@@ -83,13 +83,13 @@
 		"https_key_file": "conf/ssl.key",
 		"https_force": 0,
 		"https_timeout": 30,
-        "https_header_detect": {
-            "Front-End-Https": "^on$",
-            "X-Url-Scheme": "^https$",
-            "X-Forwarded-Protocol": "^https$",
-            "X-Forwarded-Proto": "^https$",
-            "X-Forwarded-Ssl": "^on$"
-        }
+		"https_header_detect": {
+			"Front-End-Https": "^on$",
+			"X-Url-Scheme": "^https$",
+			"X-Forwarded-Protocol": "^https$",
+			"X-Forwarded-Proto": "^https$",
+			"X-Forwarded-Ssl": "^on$"
+		}
 	},
 	
 	"User": {


### PR DESCRIPTION
Hi, 

I've added the _https_header_detect_ into the sample configuration. It makes cronicle work out of the box behind proxy server performing SSL encryption. (AWS load balancers, or CoudFront for example)

Should be there as a default in my opinion as it make things easier and shouldn't break any backwards compatibility. (if headers aren't provided by proxy, all works as it was)