### PR TITLE
Reverse proxy support

### DIFF
--- a/htdocs/js/app.js
+++ b/htdocs/js/app.js
@@ -253,10 +253,10 @@ app.extend({
 		// init socket.io client
 		var self = this;
 		
-		var url = this.proto + this.masterHostname + ':' + this.port;
+		var url = this.proto + this.masterHostname + ':' + (config.web_socket_port || this.port);
 		if (!config.web_socket_use_hostnames && this.servers && this.servers[this.masterHostname] && this.servers[this.masterHostname].ip) {
 			// use ip instead of hostname if available
-			url = this.proto + this.servers[this.masterHostname].ip + ':' + this.port;
+			url = this.proto + this.servers[this.masterHostname].ip + ':' + (config.web_socket_port || this.port);
 		}
 		Debug.trace("Websocket Connect: " + url);
 		
@@ -269,7 +269,7 @@ app.extend({
 		
 		var socket = this.socket = io( url, {
 			// forceNew: true,
-			transports: ['websocket'],
+			transports: ['polling','websocket'],
 			reconnection: false,
 			reconnectionDelay: 1000,
 			reconnectionDelayMax: 2000,
@@ -287,7 +287,7 @@ app.extend({
 			var session_id = app.getPref('session_id');
 			if (session_id) socket.emit( 'authenticate', { token: session_id } );
 		} );
-		
+
 		socket.on('connect_error', function(err) {
 			Debug.trace("socket.io connect error: " + err);
 		} );
@@ -414,10 +414,10 @@ app.extend({
 		Debug.trace("New Master Hostname: " + hostname);
 		this.masterHostname = hostname;
 		
-		this.base_api_url = this.proto + this.masterHostname + ':' + this.port + config.base_api_uri;
+		this.base_api_url = this.proto + this.masterHostname + ':' + (config.web_socket_port || this.port) + config.base_api_uri;
 		if (!config.web_socket_use_hostnames && this.servers && this.servers[this.masterHostname] && this.servers[this.masterHostname].ip) {
 			// use ip instead of hostname if available
-			this.base_api_url = this.proto + this.servers[this.masterHostname].ip + ':' + this.port + config.base_api_uri;
+			this.base_api_url = this.proto + this.servers[this.masterHostname].ip + ':' + (config.web_socket_port || this.port) + config.base_api_uri;
 		}
 		
 		Debug.trace("API calls now going to: " + this.base_api_url);

--- a/htdocs/js/pages/JobDetails.class.js
+++ b/htdocs/js/pages/JobDetails.class.js
@@ -865,10 +865,10 @@ Class.subclass( Page.Base, "Page.JobDetails", {
 		html += '</div>';
 		
 		// live job log tail
-		var remote_api_url = app.proto + job.hostname + ':' + app.port + config.base_api_uri;
+		var remote_api_url = app.proto + job.hostname + ':' + (config.web_socket_port || app.port) + config.base_api_uri;
 		if (!config.web_socket_use_hostnames && app.servers && app.servers[job.hostname] && app.servers[job.hostname].ip) {
 			// use ip if available, may work better in some setups
-			remote_api_url = app.proto + app.servers[job.hostname].ip + ':' + app.port + config.base_api_uri;
+			remote_api_url = app.proto + app.servers[job.hostname].ip + ':' + (config.web_socket_port || app.port) + config.base_api_uri;
 		}
 		
 		html += '<div class="subtitle" style="margin-top:15px;">';
@@ -1039,10 +1039,10 @@ Class.subclass( Page.Base, "Page.JobDetails", {
 		var $cont = null;
 		var chunk_count = 0;
 		
-		var url = app.proto + job.hostname + ':' + app.port;
+		var url = app.proto + job.hostname + ':' + (config.web_socket_port || app.port);
 		if (!config.web_socket_use_hostnames && app.servers && app.servers[job.hostname] && app.servers[job.hostname].ip) {
 			// use ip if available, may work better in some setups
-			url = app.proto + app.servers[job.hostname].ip + ':' + app.port;
+			url = app.proto + app.servers[job.hostname].ip + ':' + (config.web_socket_port || app.port);
 		}
 		
 		this.socket = io( url, {

--- a/lib/api/config.js
+++ b/lib/api/config.js
@@ -35,6 +35,7 @@ module.exports = Class.create({
 				external_users: this.usermgr.config.get('external_user_api') ? 1 : 0,
 				external_user_api: this.usermgr.config.get('external_user_api') || '',
 				web_socket_use_hostnames: this.server.config.get('web_socket_use_hostnames') || 0,
+                               web_socket_port: this.server.config.get('web_socket_port') || 0
 			} ),
 			port: args.request.headers.ssl ? this.web.config.get('https_port') : this.web.config.get('http_port'),
 			master_hostname: this.multi.masterHostname

--- a/sample_conf/config.json
+++ b/sample_conf/config.json
@@ -27,6 +27,7 @@
 	
 	"server_comm_use_hostnames": 0,
 	"web_socket_use_hostnames": 0,
+	"web_socket_port": 0,
 	
 	"job_memory_max": 1073741824,
 	"job_memory_sustain": 0,


### PR DESCRIPTION
Added ability to change the API port instead of using "http_port" on the web interface. Added "polling" transport to socket.io. The socket.io client will first initiate a session using polling then upgrade to websockets if available.

This branch allows the user to use their own http server (apache / nginx) and reverse proxy to Cronicle. 