### PR TITLE
Get rid of perl dependencies in scripts

### DIFF
--- a/bin/control.sh
+++ b/bin/control.sh
@@ -22,9 +22,7 @@
 NAME="Cronicle Daemon"
 #
 # home directory
-SCRIPT=`perl -MCwd -le 'print Cwd::abs_path(shift)' "$0"`
-DIR=`dirname $SCRIPT`
-HOMEDIR=`dirname $DIR`
+HOMEDIR="$(dirname "$(cd -- "$(dirname "$0")" && (pwd -P 2>/dev/null || pwd))")"
 cd $HOMEDIR
 #
 # the path to your binary, including options if necessary

--- a/bin/debug.sh
+++ b/bin/debug.sh
@@ -4,9 +4,7 @@
 # No daemon fork, and all logs emitted to stdout
 # Add --master to force instant master on startup
 
-SCRIPT=`perl -MCwd -le 'print Cwd::abs_path(shift)' "$0"`
-DIR=`dirname $SCRIPT`
-HOMEDIR=`dirname $DIR`
+HOMEDIR="$(dirname "$(cd -- "$(dirname "$0")" && (pwd -P 2>/dev/null || pwd))")"
 
 cd $HOMEDIR
 node --expose_gc --always_compact --trace-warnings $HOMEDIR/lib/main.js --debug --echo "$@"


### PR DESCRIPTION
Remove perl snippets from control.sh and debug.sh scripts.

The perl script ```perl -MCwd -le 'print Cwd::abs_path(shift)' "$0"``` is probably the best way to reliably resolve the real physical path of the current running script but I think it's a huge dependency for just control scripts...

I replaced them with a somewhat similar _POSIX sh_ expression that should reliably find the setup location of Cronicle in most cases. 

```bash
HOMEDIR="$(dirname "$(cd -- "$(dirname "$0")" && (pwd -P 2>/dev/null || pwd))")"
```

Explanation : 

- ```$(cd -- "$(dirname "$0")``` change directory to the one containing the running script
- ```(pwd -P 2>/dev/null || pwd))``` try to retrieve the current directory physical path, if ```pwd -P``` fails (some really old unix shell not supporting ```-P``` option), simply retrieve the current path whatever...
- Finally the prefixed ```"$(dirname "...")"``` retrieve the parent directory where ```lib/main.js``` should reside
- Everything run in sub-shells due to ```$( )``` syntax, so the current working directory is never changed in the top-level execution

It will work if the scripts are called from a path with symlinks, but it won't work if the script file is a symlink itself, I judged from the issue #8 that it would be enough for the use cases the perl script was used for...

A future improvement could be to rely on a node module to reduce the dependencies needed to start the software.

Like my other remarks or contributions this is mainly targeted to help running Cronicle in a Docker Container.