### PR TITLE
Added polling transport to websockets

### DIFF
--- a/htdocs/js/app.js
+++ b/htdocs/js/app.js
@@ -272,7 +272,7 @@ app.extend({
 		
 		var socket = this.socket = io( url, {
 			// forceNew: true,
-			transports: ['websocket'],
+			transports: ['polling', 'websocket'],
 			reconnection: false,
 			reconnectionDelay: 1000,
 			reconnectionDelayMax: 2000,


### PR DESCRIPTION
Allow socket.io to first try polling for requests for load balancers that do not support web sockets. The socket will be upgraded to websockets if available.