### PR TITLE
Updated control.sh to allow for symlinking to the control script

### DIFF
--- a/bin/control.sh
+++ b/bin/control.sh
@@ -22,7 +22,7 @@
 NAME="Cronicle Daemon"
 #
 # home directory
-HOMEDIR="$(dirname "$(cd -- "$(dirname "$0")" && (pwd -P 2>/dev/null || pwd))")"
+HOMEDIR="$(dirname "$(cd -- "$(dirname "$(readlink -f "$0")")" && (pwd -P 2>/dev/null || pwd))")"
 cd $HOMEDIR
 #
 # the path to your binary, including options if necessary


### PR DESCRIPTION
The patch allows a symlink to the control.sh to resolve to the actual location of the cronicle control script. Useful when you are adding a symlink to control.sh into another folder on your system (e.g. /etc/init.d) and want it to still find the process .pid file in the actual location, instead of looking in the folder where the link is.