### PR TITLE
Fixed bug where reset password would not allow "-" and "." chars

### DIFF
--- a/htdocs/js/pages/Login.class.js
+++ b/htdocs/js/pages/Login.class.js
@@ -306,7 +306,7 @@ Class.subclass( Page.Base, "Page.Login", {
 		var username = trim($('#fe_pr_username').val()).toLowerCase();
 		var email = trim($('#fe_pr_email').val());
 		
-		if (username.match(/^\w+$/)) {
+		if (username.match(/^[\w.-]+$/)) {
 			if (email.match(/.+\@.+/)) {
 				Dialog.hide();
 				app.showProgress( 1.0, "Sending e-mail..." );


### PR DESCRIPTION
On the Reset Password page, if you input any usernames with "." or "-" chars (which are valid chars and can be used to create new users), cronicle will complain that no valid users were found.

This is basically just a regex change to consider also "." and "-" as valid username characthers.