### PR TITLE
close the child's stdin after writing all of the payload

### DIFF
--- a/bin/shell-plugin.js
+++ b/bin/shell-plugin.js
@@ -118,6 +118,7 @@ stream.on('json', function(job) {
 	
 	// pass job down to child process (harmless for shell, useful for php/perl/node)
 	cstream.write( job );
+	child.stdin.end();
 	
 	// Handle shutdown
 	process.on('SIGTERM', function() { 


### PR DESCRIPTION
This fix will close the child's stdin, allowing you to read to the end and acquire all of the stat information.

For example, using `shell-plugin.js`, we can now include something like the following in our script - in this case to get the source of the job.

```bash
cat > job_info

jq -r '.source' < job_info
```

Previously this would have been impossible, as the pipe was never closed, and thus we'd never get EOF... the effect is that the job appears to hang.