### PR TITLE
added query string flag to prevent merging post data into the root of params

### DIFF
--- a/README.md
+++ b/README.md
@@ -2957,6 +2957,8 @@ Example response:
 }
 ```
 
+If you do not wish to merge the POST data into the `params` (for example if you are using a webhook that provides other data as JSON), then you can add the `merge_params=no` parameter to the query string. If you do this, then the POST data will be available in the `post_data` key of the `params` object.
+
 In addition to the [Standard Response Format](#standard-response-format), the IDs of all the launched jobs will be returned in the `ids` array.  Typically only a single job is launched, but it may be multiple if the event has [Multiplexing](#multiplexing) enabled and targets a group with multiple servers.
 
 If [Allow Queued Jobs](#allow-queued-jobs) is enabled on the event, the API response will also include a `queue` property, which will be set to the number of jobs currently queued up.

--- a/lib/api/event.js
+++ b/lib/api/event.js
@@ -339,7 +339,15 @@ module.exports = Class.create({
 		// run event manually (via "Run" button in UI or by API Key)
 		// can include any event overrides in params (such as 'now')
 		var self = this;
-		var params = Tools.mergeHashes( args.params, args.query );
+		var params, post_data;
+		if (!args.query.merge_params) args.query.merge_params = 'yes';
+		if (args.query.merge_params == 'yes') {
+			params = Tools.mergeHashes( args.params, args.query );
+			params['post_data'] = null;
+		} else {
+			params = Tools.copyHash(args.query, true);
+			params['post_data'] = args.params;
+		}
 		if (!this.requireMaster(args, callback)) return;
 		
 		var criteria = {};


### PR DESCRIPTION
When using webhooks from other services (for example GitLab), it needs to be possible to keep their data separate from the Cronicle `params` data.

This patch will add a `merge_params` parameter to the `/api/app/run_event/v1` endpoint, allowing this merging to be disabled.

For example, you might set up the following URL in a GitLab integration / web hook:

```
https://${my_cronicle}/api/app/run_event/v1?api_key=${my_key}id=${my_event}&merge_params=no
```

Pairing this with #253 will allow access to the GitLab data in a clean way, using a shelll script like this:

```bash
#!/bin/bash

set -eu -o pipefail

cleanup() {
    [ ! -z "${params:+z}" ] && rm "${params}"
    [ ! -z "${extra:+z}"  ] && rm "${extra}"
}
trap cleanup EXIT

# keep the params data
params="$(mktemp)"
jq -c '.' > "${params}"

# only accept pipeline notifications
read object_kind < <( jq -r '.post_data.object_kind' < "${params}" )
if [ "${object_kind}" != "pipeline" ]; then
    echo "WARNING: ignoring non-pipeline event... (${object_kind})" >&2
    exit 0
fi

# only accept success notifications
read object_status < <( jq -r '.post_data.object_attributes.status' < "${params}" )
if [ "${object_status}" != "success" ]; then
    echo "WARNING: ignoring non-success event... (${object_status})" >&2
    exit 0
fi

# locate gitlab
read gitlab_project_url < <( jq -r '.post_data.project.web_url'             < "${params}" )
read gitlab_namespace   < <( jq -r '.post_data.project.path_with_namespace' < "${params}" )
len=$(( ${#gitlab_project_url} - ${#gitlab_namespace} - 1 ))
gitlab_url="${gitlab_project_url::${len}}"
gitlab_api="${gitlab_url}/api/v4"

# get the necessary information
read project_id   < <( jq -r '.post_data.project.id'     < "${params}"  )
read build_id     < <( jq -r '.post_data.builds[0].id'   < "${params}"  )

# build the URL
artifact="ARTIFACT.TGZ"
gtlab_token="GITLAB_TOKEN"
url="${gitlab_api}/projects/${project_id}/jobs/${build_id}/artifacts/${artifact}"

curl -s --header "PRIVATE-TOKEN:${gitlab_token}" "${url}" \
    | gzip -d \
    | tar -t
```