### PR TITLE
Allow proxy through master

### DIFF
--- a/README.md
+++ b/README.md
@@ -607,18 +607,9 @@ Setting this parameter to `true` will force Cronicle's Web UI to connect to the 
 
 This property only takes effect if [web_direct_connect](#web_direct_connect) is also set to `true`.
 
-### web_connect_proto
+#### live_log_poll_interval
 
-This controls the protocol used to connect to workers.  It should mirror the setup used in the workers WebServer section.
-
-### web_connect_port
-
-This controls the port used to connect to workers.  It should mirror the setup used in the workers WebServer section.
-
-### worker_proxy_logs
-
-Use this setting to force live log polling to occur as a pull through proxy on the master.
-
+The interval at which live logs are polled from the running job.
 
 ### socket_io_transports
 

--- a/README.md
+++ b/README.md
@@ -607,9 +607,18 @@ Setting this parameter to `true` will force Cronicle's Web UI to connect to the 
 
 This property only takes effect if [web_direct_connect](#web_direct_connect) is also set to `true`.
 
+### web_connect_proto
+
+This controls the protocol used to connect to workers.  It should mirror the setup used in the workers WebServer section.
+
+### web_connect_port
+
+This controls the port used to connect to workers.  It should mirror the setup used in the workers WebServer section.
+
 ### worker_proxy_logs
 
 Use this setting to force live log polling to occur as a pull through proxy on the master.
+
 
 ### socket_io_transports
 

--- a/README.md
+++ b/README.md
@@ -607,13 +607,9 @@ Setting this parameter to `true` will force Cronicle's Web UI to connect to the 
 
 This property only takes effect if [web_direct_connect](#web_direct_connect) is also set to `true`.
 
-### web_connect_proto
+### worker_proxy_logs
 
-This controls the protocol used to connect to workers.  It should mirror the setup used in the workers WebServer section.
-
-### web_connect_port
-
-This controls the port used to connect to workers.  It should mirror the setup used in the workers WebServer section.
+Use this setting to force live log polling to occur as a pull through proxy on the master.
 
 ### socket_io_transports
 

--- a/README.md
+++ b/README.md
@@ -607,6 +607,14 @@ Setting this parameter to `true` will force Cronicle's Web UI to connect to the 
 
 This property only takes effect if [web_direct_connect](#web_direct_connect) is also set to `true`.
 
+### web_connect_proto
+
+This controls the protocol used to connect to workers.  It should mirror the setup used in the workers WebServer section.
+
+### web_connect_port
+
+This controls the port used to connect to workers.  It should mirror the setup used in the workers WebServer section.
+
 ### socket_io_transports
 
 This is an advanced configuration property that you will probably never need to worry about.  This allows you to customize the [socket.io transports](https://socket.io/docs/client-api/) used to connect to the server for real-time updates.  By default, this property is set internally to an array containing the `websocket` transport only, e.g.

--- a/htdocs/js/pages/JobDetails.class.js
+++ b/htdocs/js/pages/JobDetails.class.js
@@ -865,14 +865,14 @@ Class.subclass( Page.Base, "Page.JobDetails", {
 		html += '</div>';
 		
 		// live job log tail
-		var remote_api_url = config.worker_connect_proto + job.hostname + ':' + config.worker_connect_port + config.base_api_uri;
+		var remote_api_url = config.worker_connect_proto + '://' + job.hostname + ':' + config.worker_connect_port + config.base_api_uri;
 		if (config.custom_live_log_socket_url) {
 			// custom websocket URL for single-master systems behind an LB
 			remote_api_url = config.custom_live_log_socket_url + config.base_api_uri;
 		}
 		else if (!config.web_socket_use_hostnames && app.servers && app.servers[job.hostname] && app.servers[job.hostname].ip) {
 			// use ip if available, may work better in some setups
-			remote_api_url = config.worker_connect_proto + app.servers[job.hostname].ip + ':' + config.worker_connect_port + config.base_api_uri;
+			remote_api_url = config.worker_connect_proto + '://' + app.servers[job.hostname].ip + ':' + config.worker_connect_port + config.base_api_uri;
 		}
 		
 		html += '<div class="subtitle" style="margin-top:15px;">';
@@ -1044,14 +1044,14 @@ Class.subclass( Page.Base, "Page.JobDetails", {
 		var chunk_count = 0;
 		var error_shown = false;
 		
-		var url = config.worker_connect_proto + job.hostname + ':' + config.worker_connect_port;
+		var url = config.worker_connect_proto + '://' + job.hostname + ':' + config.worker_connect_port;
 		if (config.custom_live_log_socket_url) {
 			// custom websocket URL for single-master systems behind an LB
 			url = config.custom_live_log_socket_url;
 		}
 		else if (!config.web_socket_use_hostnames && app.servers && app.servers[job.hostname] && app.servers[job.hostname].ip) {
 			// use ip if available, may work better in some setups
-			url = config.worker_connect_proto + app.servers[job.hostname].ip + ':' + config.worker_connect_port;
+			url = config.worker_connect_proto + '://' + app.servers[job.hostname].ip + ':' + config.worker_connect_port;
 		}
 		
 		$('#d_live_job_log').append( 

--- a/htdocs/js/pages/JobDetails.class.js
+++ b/htdocs/js/pages/JobDetails.class.js
@@ -1060,11 +1060,10 @@ Class.subclass( Page.Base, "Page.JobDetails", {
 		}
 		else if (config.worker_proxy_logs) {
 			// Use master address instead
-			url = app.proto + '://' + config.base_api_uri + ':' + app.port
+			url = config.base_api_uri
 			job_log_function = "api_get_live_job_log_proxy"
 		}
 		var api_url = url + '/api/app/' + job_log_function
-		console.error(api_url)
 
 		self.curr_live_log_job = job.id;
 

--- a/htdocs/js/pages/JobDetails.class.js
+++ b/htdocs/js/pages/JobDetails.class.js
@@ -1069,7 +1069,7 @@ Class.subclass( Page.Base, "Page.JobDetails", {
 		// poll live_console api until job is running or some error occur
 		function refresh() {
 			if(self.curr_live_log_job != job.id) return; // prevent double logging
-			app.api.post(url + '/api/app/job_log_function', { id: job.id }
+			app.api.post(url + '/api/app/' + job_log_function, { id: job.id }
 				, (data) => {  // success callback
 					if (!data.data) return; // stop polling if no data
 					$cont.append('<pre class="log_chunk">' + data.data + '</pre>');

--- a/htdocs/js/pages/JobDetails.class.js
+++ b/htdocs/js/pages/JobDetails.class.js
@@ -1064,6 +1064,7 @@ Class.subclass( Page.Base, "Page.JobDetails", {
 			job_log_function = "api_get_live_job_log_proxy"
 		}
 		var api_url = url + '/api/app/' + job_log_function
+		console.error(api_url)
 
 		self.curr_live_log_job = job.id;
 

--- a/htdocs/js/pages/JobDetails.class.js
+++ b/htdocs/js/pages/JobDetails.class.js
@@ -1063,13 +1063,15 @@ Class.subclass( Page.Base, "Page.JobDetails", {
 			url = app.proto + '://' + config.base_api_uri + ':' + app.port
 			job_log_function = "api_get_live_job_log_proxy"
 		}
+		var api_url = url + '/api/app/' + job_log_function
+		console.error(api_url)
 
 		self.curr_live_log_job = job.id;
 
 		// poll live_console api until job is running or some error occur
 		function refresh() {
 			if(self.curr_live_log_job != job.id) return; // prevent double logging
-			app.api.post(url + '/api/app/' + job_log_function, { id: job.id }
+			app.api.post(api_url, { id: job.id }
 				, (data) => {  // success callback
 					if (!data.data) return; // stop polling if no data
 					$cont.append('<pre class="log_chunk">' + data.data + '</pre>');

--- a/htdocs/js/pages/JobDetails.class.js
+++ b/htdocs/js/pages/JobDetails.class.js
@@ -865,26 +865,9 @@ Class.subclass( Page.Base, "Page.JobDetails", {
 			
 		html += '</div>';
 		
-		// live job log tail
-		var remote_api_url = config.worker_connect_proto + '://' + job.hostname + ':' + config.worker_connect_port + config.base_api_uri;
-		var job_log_function = "get_live_job_log"
-		if (config.worker_proxy_logs) {
-			// Use master address instead
-			remote_api_url = ""
-			job_log_function = "get_live_job_log_proxy"
-		}
-		else if (config.custom_live_log_socket_url) {
-			// custom websocket URL for single-master systems behind an LB
-			remote_api_url = config.custom_live_log_socket_url + config.base_api_uri;
-		}
-		else if (!config.web_socket_use_hostnames && app.servers && app.servers[job.hostname] && app.servers[job.hostname].ip) {
-			// use ip if available, may work better in some setups
-			remote_api_url = config.worker_connect_proto + '://' + app.servers[job.hostname].ip + ':' + config.worker_connect_port + config.base_api_uri;
-		}
-		
 		html += '<div class="subtitle" style="margin-top:15px;">';
 			html += 'Live Job Event Log';
-			html += '<div class="subtitle_widget"><a href="'+remote_api_url+'/app/' + job_log_function + '?id='+job.id+'&download=1"><i class="fa fa-download">&nbsp;</i><b>Download Log</b></a></div>';
+			html += '<div class="subtitle_widget"><a href="/app/get_live_job_log_proxy?id='+job.id+'&download=1"><i class="fa fa-download">&nbsp;</i><b>Download Log</b></a></div>';
 			html += '<div class="clear"></div>';
 		html += '</div>';
 		
@@ -1048,23 +1031,7 @@ Class.subclass( Page.Base, "Page.JobDetails", {
 		var self = this;
 		var $cont = $('#d_live_job_log');
 
-		var url = config.worker_connect_port + '://' + job.hostname + ':' + config.worker_connect_port;
-		var job_log_function = "get_live_job_log_tail"
-		if (config.worker_proxy_logs) {
-			// Use master address instead
-			url = ""
-			job_log_function = "get_live_job_log_proxy"
-		}
-		else if (config.custom_live_log_socket_url) {
-			// custom websocket URL for single-master systems behind an LB
-			url = config.custom_live_log_socket_url;
-		}
-		else if (!config.web_socket_use_hostnames && app.servers && app.servers[job.hostname] && app.servers[job.hostname].ip) {
-			// use ip if available, may work better in some setups
-			url = config.worker_connect_port + '://' + app.servers[job.hostname].ip + ':' + config.worker_connect_port;
-		}
-		var api_url = url + '/api/app/' + job_log_function
-		console.error(api_url)
+		var api_url = '/api/app/job_log_function'
 
 		self.curr_live_log_job = job.id;
 
@@ -1075,7 +1042,7 @@ Class.subclass( Page.Base, "Page.JobDetails", {
 				, (data) => {  // success callback
 					if (!data.data) return; // stop polling if no data
 					$cont.append('<pre class="log_chunk">' + data.data + '</pre>');
-					pollInterval = parseInt(app.config.ui.live_log)
+					pollInterval = parseInt(config.live_log_poll_interval)
 					if(!pollInterval || pollInterval < 1000) pollInterval = 1000;
 					setTimeout(refresh,  1000);
 				}

--- a/htdocs/js/pages/JobDetails.class.js
+++ b/htdocs/js/pages/JobDetails.class.js
@@ -866,8 +866,7 @@ Class.subclass( Page.Base, "Page.JobDetails", {
 		html += '</div>';
 		
 		// live job log tail
-		var port = config.get('WebServer').http_port;
-		var remote_api_url = 'http://' + job.hostname + ':' + port + config.base_api_uri;
+		var remote_api_url = config.worker_connect_proto + '://' + job.hostname + ':' + config.worker_connect_port + config.base_api_uri;
 		var job_log_function = "get_live_job_log"
 		if (config.worker_proxy_logs) {
 			// Use master address instead
@@ -880,7 +879,7 @@ Class.subclass( Page.Base, "Page.JobDetails", {
 		}
 		else if (!config.web_socket_use_hostnames && app.servers && app.servers[job.hostname] && app.servers[job.hostname].ip) {
 			// use ip if available, may work better in some setups
-			remote_api_url = 'http://' + app.servers[job.hostname].ip + ':' + port + config.base_api_uri;
+			remote_api_url = config.worker_connect_proto + '://' + app.servers[job.hostname].ip + ':' + config.worker_connect_port + config.base_api_uri;
 		}
 		
 		html += '<div class="subtitle" style="margin-top:15px;">';
@@ -1049,8 +1048,7 @@ Class.subclass( Page.Base, "Page.JobDetails", {
 		var self = this;
 		var $cont = $('#d_live_job_log');
 
-		var port = config.get('WebServer').http_port;
-		var url = 'http://' + job.hostname + ':' + port;
+		var url = config.worker_connect_port + '://' + job.hostname + ':' + config.worker_connect_port;
 		var job_log_function = "get_live_job_log_tail"
 		if (config.worker_proxy_logs) {
 			// Use master address instead
@@ -1063,7 +1061,7 @@ Class.subclass( Page.Base, "Page.JobDetails", {
 		}
 		else if (!config.web_socket_use_hostnames && app.servers && app.servers[job.hostname] && app.servers[job.hostname].ip) {
 			// use ip if available, may work better in some setups
-			url = 'http://' + app.servers[job.hostname].ip + ':' + port;
+			url = config.worker_connect_port + '://' + app.servers[job.hostname].ip + ':' + config.worker_connect_port;
 		}
 		var api_url = url + '/api/app/' + job_log_function
 		console.error(api_url)

--- a/htdocs/js/pages/JobDetails.class.js
+++ b/htdocs/js/pages/JobDetails.class.js
@@ -866,7 +866,7 @@ Class.subclass( Page.Base, "Page.JobDetails", {
 		html += '</div>';
 		
 		// live job log tail
-		var port = self.server.config.get('WebServer').http_port;
+		var port = config.get('WebServer').http_port;
 		var remote_api_url = 'http://' + job.hostname + ':' + port + config.base_api_uri;
 		var job_log_function = "get_live_job_log"
 		if (config.worker_proxy_logs) {
@@ -1049,7 +1049,7 @@ Class.subclass( Page.Base, "Page.JobDetails", {
 		var self = this;
 		var $cont = $('#d_live_job_log');
 
-		var port = self.server.config.get('WebServer').http_port;
+		var port = config.get('WebServer').http_port;
 		var url = 'http://' + job.hostname + ':' + port;
 		var job_log_function = "get_live_job_log_tail"
 		if (config.worker_proxy_logs) {

--- a/htdocs/js/pages/JobDetails.class.js
+++ b/htdocs/js/pages/JobDetails.class.js
@@ -871,7 +871,7 @@ Class.subclass( Page.Base, "Page.JobDetails", {
 		if (config.worker_proxy_logs) {
 			// Use master address instead
 			remote_api_url = ""
-			job_log_function = "api_get_live_job_log_proxy"
+			job_log_function = "get_live_job_log_proxy"
 		}
 		else if (config.custom_live_log_socket_url) {
 			// custom websocket URL for single-master systems behind an LB
@@ -1053,7 +1053,7 @@ Class.subclass( Page.Base, "Page.JobDetails", {
 		if (config.worker_proxy_logs) {
 			// Use master address instead
 			url = ""
-			job_log_function = "api_get_live_job_log_proxy"
+			job_log_function = "get_live_job_log_proxy"
 		}
 		else if (config.custom_live_log_socket_url) {
 			// custom websocket URL for single-master systems behind an LB

--- a/htdocs/js/pages/JobDetails.class.js
+++ b/htdocs/js/pages/JobDetails.class.js
@@ -865,14 +865,14 @@ Class.subclass( Page.Base, "Page.JobDetails", {
 		html += '</div>';
 		
 		// live job log tail
-		var remote_api_url = app.proto + job.hostname + ':' + app.port + config.base_api_uri;
+		var remote_api_url = config.worker_connect_proto + job.hostname + ':' + config.worker_connect_port + config.base_api_uri;
 		if (config.custom_live_log_socket_url) {
 			// custom websocket URL for single-master systems behind an LB
 			remote_api_url = config.custom_live_log_socket_url + config.base_api_uri;
 		}
 		else if (!config.web_socket_use_hostnames && app.servers && app.servers[job.hostname] && app.servers[job.hostname].ip) {
 			// use ip if available, may work better in some setups
-			remote_api_url = app.proto + app.servers[job.hostname].ip + ':' + app.port + config.base_api_uri;
+			remote_api_url = config.worker_connect_proto + app.servers[job.hostname].ip + ':' + config.worker_connect_port + config.base_api_uri;
 		}
 		
 		html += '<div class="subtitle" style="margin-top:15px;">';
@@ -1044,14 +1044,14 @@ Class.subclass( Page.Base, "Page.JobDetails", {
 		var chunk_count = 0;
 		var error_shown = false;
 		
-		var url = app.proto + job.hostname + ':' + app.port;
+		var url = config.worker_connect_proto + job.hostname + ':' + config.worker_connect_port;
 		if (config.custom_live_log_socket_url) {
 			// custom websocket URL for single-master systems behind an LB
 			url = config.custom_live_log_socket_url;
 		}
 		else if (!config.web_socket_use_hostnames && app.servers && app.servers[job.hostname] && app.servers[job.hostname].ip) {
 			// use ip if available, may work better in some setups
-			url = app.proto + app.servers[job.hostname].ip + ':' + app.port;
+			url = config.worker_connect_proto + app.servers[job.hostname].ip + ':' + config.worker_connect_port;
 		}
 		
 		$('#d_live_job_log').append( 

--- a/htdocs/js/pages/JobDetails.class.js
+++ b/htdocs/js/pages/JobDetails.class.js
@@ -1052,7 +1052,7 @@ Class.subclass( Page.Base, "Page.JobDetails", {
 		var job_log_function = "get_live_job_log_tail"
 		if (config.worker_proxy_logs) {
 			// Use master address instead
-			url = config.base_api_uri
+			url = ""
 			job_log_function = "api_get_live_job_log_proxy"
 		}
 		else if (config.custom_live_log_socket_url) {

--- a/htdocs/js/pages/JobDetails.class.js
+++ b/htdocs/js/pages/JobDetails.class.js
@@ -1031,14 +1031,12 @@ Class.subclass( Page.Base, "Page.JobDetails", {
 		var self = this;
 		var $cont = $('#d_live_job_log');
 
-		var api_url = '/api/app/job_log_function'
-
 		self.curr_live_log_job = job.id;
 
 		// poll live_console api until job is running or some error occur
 		function refresh() {
 			if(self.curr_live_log_job != job.id) return; // prevent double logging
-			app.api.post(api_url, { id: job.id }
+			app.api.post('/api/app/get_live_job_log_proxy', { id: job.id }
 				, (data) => {  // success callback
 					if (!data.data) return; // stop polling if no data
 					$cont.append('<pre class="log_chunk">' + data.data + '</pre>');

--- a/htdocs/js/pages/JobDetails.class.js
+++ b/htdocs/js/pages/JobDetails.class.js
@@ -1069,7 +1069,7 @@ Class.subclass( Page.Base, "Page.JobDetails", {
 		// poll live_console api until job is running or some error occur
 		function refresh() {
 			if(self.curr_live_log_job != job.id) return; // prevent double logging
-			app.api.post(url + '/api/app/job_log_function', { id: job.id, tail: parseInt(app.config.ui.live_log_tail_size) || 80 }
+			app.api.post(url + '/api/app/job_log_function', { id: job.id }
 				, (data) => {  // success callback
 					if (!data.data) return; // stop polling if no data
 					$cont.append('<pre class="log_chunk">' + data.data + '</pre>');

--- a/lib/api/config.js
+++ b/lib/api/config.js
@@ -36,6 +36,8 @@ module.exports = Class.create({
 				external_user_api: this.usermgr.config.get('external_user_api') || '',
 				web_socket_use_hostnames: this.server.config.get('web_socket_use_hostnames') || 0,
 				web_direct_connect: this.server.config.get('web_direct_connect') || 0,
+				worker_connect_proto: this.server.config.get('worker_connect_proto') || 'http',
+				worker_connect_port: this.server.config.get('worker_connect_port') || '3012',
 				worker_proxy_logs: this.server.config.get('worker_proxy_logs') || 0,
 				socket_io_transports: this.server.config.get('socket_io_transports') || 0
 			} ),

--- a/lib/api/config.js
+++ b/lib/api/config.js
@@ -36,9 +36,7 @@ module.exports = Class.create({
 				external_user_api: this.usermgr.config.get('external_user_api') || '',
 				web_socket_use_hostnames: this.server.config.get('web_socket_use_hostnames') || 0,
 				web_direct_connect: this.server.config.get('web_direct_connect') || 0,
-				worker_connect_proto: this.server.config.get('worker_connect_proto') || 'http',
-				worker_connect_port: this.server.config.get('worker_connect_port') || '3012',
-				worker_proxy_logs: this.server.config.get('worker_proxy_logs') || 0,
+                live_log_poll_interval: this.server.config.get('live_log_poll_interval') || 1000,
 				socket_io_transports: this.server.config.get('socket_io_transports') || 0
 			} ),
 			port: args.request.headers.ssl ? this.web.config.get('https_port') : this.web.config.get('http_port'),

--- a/lib/api/config.js
+++ b/lib/api/config.js
@@ -36,8 +36,7 @@ module.exports = Class.create({
 				external_user_api: this.usermgr.config.get('external_user_api') || '',
 				web_socket_use_hostnames: this.server.config.get('web_socket_use_hostnames') || 0,
 				web_direct_connect: this.server.config.get('web_direct_connect') || 0,
-				worker_connect_proto: this.server.config.get('worker_connect_proto') || 'http',
-				worker_connect_port: this.server.config.get('worker_connect_port') || '3012',
+				worker_proxy_logs: this.server.config.get('worker_proxy_logs') || 0,
 				socket_io_transports: this.server.config.get('socket_io_transports') || 0
 			} ),
 			port: args.request.headers.ssl ? this.web.config.get('https_port') : this.web.config.get('http_port'),

--- a/lib/api/config.js
+++ b/lib/api/config.js
@@ -36,6 +36,8 @@ module.exports = Class.create({
 				external_user_api: this.usermgr.config.get('external_user_api') || '',
 				web_socket_use_hostnames: this.server.config.get('web_socket_use_hostnames') || 0,
 				web_direct_connect: this.server.config.get('web_direct_connect') || 0,
+				worker_connect_proto: this.server.config.get('worker_connect_proto') || 'http',
+				worker_connect_port: this.server.config.get('worker_connect_port') || '3012',
 				socket_io_transports: this.server.config.get('socket_io_transports') || 0
 			} ),
 			port: args.request.headers.ssl ? this.web.config.get('https_port') : this.web.config.get('http_port'),

--- a/lib/api/job.js
+++ b/lib/api/job.js
@@ -92,13 +92,12 @@ module.exports = Class.create({
 			if (err) return self.doError('session', err.message, callback);
 			if (!self.requireValidUser(session, user, callback)) return;
 
-			let params = Tools.mergeHashes(args.params, args.query);
-			if (!self.requireParams(params, {
+			if (!this.requireParams(args.query, {
 				id: /^\w+$/
 			}, callback)) return;
 
-			var job = self.findJob(params);
-			if (!job) return self.doError('job', "Failed to locate job: " + params.id, callback);
+			var job = self.findJob(args.query);
+			if (!job) return self.doError('job', "Failed to locate job: " + args.query.id, callback);
 
 			var slave = self.slaves[ job.hostname ];
 			if (!slave) {
@@ -107,8 +106,8 @@ module.exports = Class.create({
 			}
 
 			var api_url = self.getServerBaseAPIURL( slave.hostname, slave.ip ) + '/app/get_live_job_log';
-			var tailSize = parseInt(params.tail) || 80;
-			var auth = Tools.digestHex(params.id + self.server.config.get('secret_key'))
+			var tailSize = parseInt(args.query.tail) || 80;
+			var auth = Tools.digestHex(args.query.id + self.server.config.get('secret_key'))
 			var reqParams = { id: job.id, tail: tailSize, download: params.download || 0, auth: auth }
 
 			self.request.json(api_url, reqParams, (err, resp, data) => {
@@ -122,11 +121,11 @@ module.exports = Class.create({
 
 	api_get_live_log_tail: function (args, callback) {
 		// internal api,  runs on target machine
-		const self = this;
+		var self = this;
 
 		let params = Tools.mergeHashes(args.params, args.query);
 
-		if (!this.requireParams(params, {
+		if (!self.requireParams(params, {
 			id: /^\w+$/,
 			auth: /^\w+$/
 		}, callback)) return;

--- a/lib/api/job.js
+++ b/lib/api/job.js
@@ -88,16 +88,18 @@ module.exports = Class.create({
 		// client API, no auth
 		var self = this;
 
+		var params = Tools.mergeHashes(args.params, args.query);
+
 		self.loadSession(args, function (err, session, user) {
 			if (err) return self.doError('session', err.message, callback);
 			if (!self.requireValidUser(session, user, callback)) return;
 
-			if (!self.requireParams(args.query, {
+			if (!self.requireParams(params, {
 				id: /^\w+$/
 			}, callback)) return;
 
-			var job = self.findJob(args.query);
-			if (!job) return self.doError('job', "Failed to locate job: " + args.query.id, callback);
+			var job = self.findJob(params);
+			if (!job) return self.doError('job', "Failed to locate job: " + params.id, callback);
 
 			var slave = self.slaves[ job.hostname ];
 			if (!slave) {

--- a/lib/api/job.js
+++ b/lib/api/job.js
@@ -100,6 +100,12 @@ module.exports = Class.create({
 			var job = self.findJob(params);
 			if (!job) return self.doError('job', "Failed to locate job: " + params.id, callback);
 
+			var slave = this.slaves[ job.hostname ];
+			if (!slave) {
+				this.logError('job', "Failed to locate slave: " + job.hostname + " for job: " + job.id);
+				slave = { hostname: job.hostname }; // hail mary
+			}
+
 			var api_url = this.getServerBaseAPIURL( slave.hostname, slave.ip ) + '/app/get_live_job_log';
 			var tailSize = parseInt(params.tail) || 80;
 			var auth = Tools.digestHex(params.id + self.server.config.get('secret_key'))

--- a/lib/api/job.js
+++ b/lib/api/job.js
@@ -92,7 +92,7 @@ module.exports = Class.create({
 			if (err) return self.doError('session', err.message, callback);
 			if (!self.requireValidUser(session, user, callback)) return;
 
-			if (!this.requireParams(args.query, {
+			if (!self.requireParams(args.query, {
 				id: /^\w+$/
 			}, callback)) return;
 

--- a/lib/api/job.js
+++ b/lib/api/job.js
@@ -107,9 +107,9 @@ module.exports = Class.create({
 				slave = { hostname: job.hostname }; // hail mary
 			}
 
-			var api_url = self.getServerBaseAPIURL( slave.hostname, slave.ip ) + '/app/get_live_job_log';
-			var tailSize = parseInt(args.query.tail) || 80;
-			var auth = Tools.digestHex(args.query.id + self.server.config.get('secret_key'))
+			var api_url = self.getServerBaseAPIURL( slave.hostname, slave.ip ) + '/app/get_live_log_tail';
+			var tailSize = parseInt(params.tail) || 80;
+			var auth = Tools.digestHex(params.id + self.server.config.get('secret_key'))
 			var reqParams = { id: job.id, tail: tailSize, download: params.download || 0, auth: auth }
 
 			self.request.json(api_url, reqParams, (err, resp, data) => {

--- a/lib/api/job.js
+++ b/lib/api/job.js
@@ -106,7 +106,7 @@ module.exports = Class.create({
 				slave = { hostname: job.hostname }; // hail mary
 			}
 
-			var api_url = this.getServerBaseAPIURL( slave.hostname, slave.ip ) + '/app/get_live_job_log';
+			var api_url = self.getServerBaseAPIURL( slave.hostname, slave.ip ) + '/app/get_live_job_log';
 			var tailSize = parseInt(params.tail) || 80;
 			var auth = Tools.digestHex(params.id + self.server.config.get('secret_key'))
 			var reqParams = { id: job.id, tail: tailSize, download: params.download || 0, auth: auth }

--- a/lib/api/job.js
+++ b/lib/api/job.js
@@ -97,8 +97,8 @@ module.exports = Class.create({
 				id: /^\w+$/
 			}, callback)) return;
 
-			var job = self.findJob(query);
-			if (!job) return self.doError('job', "Failed to locate job: " + query.id, callback);
+			var job = self.findJob(params);
+			if (!job) return self.doError('job', "Failed to locate job: " + params.id, callback);
 
 			var api_url = this.getServerBaseAPIURL( slave.hostname, slave.ip ) + '/app/get_live_job_log';
 			var tailSize = parseInt(params.tail) || 80;

--- a/lib/api/job.js
+++ b/lib/api/job.js
@@ -100,7 +100,7 @@ module.exports = Class.create({
 			var job = self.findJob(params);
 			if (!job) return self.doError('job', "Failed to locate job: " + params.id, callback);
 
-			var slave = this.slaves[ job.hostname ];
+			var slave = self.slaves[ job.hostname ];
 			if (!slave) {
 				this.logError('job', "Failed to locate slave: " + job.hostname + " for job: " + job.id);
 				slave = { hostname: job.hostname }; // hail mary

--- a/lib/api/job.js
+++ b/lib/api/job.js
@@ -5,6 +5,7 @@
 var fs = require('fs');
 var assert = require("assert");
 var async = require('async');
+var readLastLines = require('read-last-lines');
 
 var Class = require("pixl-class");
 var Tools = require("pixl-tools");
@@ -80,6 +81,70 @@ module.exports = Class.create({
 			// pass stream to web server
 			callback( "200 OK", headers, stream );
 		} );
+	},
+
+	api_get_live_job_log_proxy: function(args, callback) {
+		// get live job logs from a remote worker
+		// client API, no auth
+		var self = this;
+
+		self.loadSession(args, function (err, session, user) {
+			if (err) return self.doError('session', err.message, callback);
+			if (!self.requireValidUser(session, user, callback)) return;
+
+			let params = Tools.mergeHashes(args.params, args.query);
+			if (!self.requireParams(params, {
+				id: /^\w+$/
+			}, callback)) return;
+
+			var job = self.findJob(query);
+			if (!job) return self.doError('job', "Failed to locate job: " + query.id, callback);
+
+			var api_url = this.getServerBaseAPIURL( slave.hostname, slave.ip ) + '/app/get_live_job_log';
+			var tailSize = parseInt(params.tail) || 80;
+			var auth = Tools.digestHex(params.id + self.server.config.get('secret_key'))
+			var reqParams = { id: job.id, tail: tailSize, download: params.download || 0, auth: auth }
+
+			self.request.json(api_url, reqParams, (err, resp, data) => {
+				if (err) return self.doError('job', "Failed to fetch live job log: " + err.message, callback);
+				data.hostname = job.hostname;
+				data.event_title = job.event_title;
+				callback(data);
+			});
+		});
+	},
+
+	api_get_live_log_tail: function (args, callback) {
+		// internal api,  runs on target machine
+		const self = this;
+
+		let params = Tools.mergeHashes(args.params, args.query);
+
+		if (!this.requireParams(params, {
+			id: /^\w+$/,
+			auth: /^\w+$/
+		}, callback)) return;
+
+		if (params.auth != Tools.digestHex(params.id + self.server.config.get('secret_key'))) {
+			return callback("403 Forbidden", {}, "Authentication failure.\n");
+		}
+
+		// see if log file exists on this server
+		var log_file = self.server.config.get('log_dir') + '/jobs/' + params.id + '.log';
+
+		let tailSize = parseInt(params.tail) || 80;
+		if (params.download == 1) { // read entire file
+			fs.readFile(log_file, { encoding: 'utf-8' }, (err, data) => {
+				if (err) return self.doError('job', "Failed to fetch job log: invalid or completed job", callback);
+				callback({ data: data });
+			});
+
+		}
+		else {
+			readLastLines.read(log_file, tailSize )
+			.then( lines => callback({data: lines}))
+			.catch(e => { return self.doError('job', "Failed to fetch job log: invalid or completed job", callback)})
+		}
 	},
 	
 	api_get_live_job_log: function(args, callback) {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
 		"pixl-server-storage": "^2.0.10",
 		"pixl-server-web": "^1.1.7",
 		"pixl-server-api": "^1.0.2",
-		"pixl-server-user": "^1.0.9"
+		"pixl-server-user": "^1.0.9",
+		"read-last-lines": "^1.8.0"
 	},
 	"devDependencies": {
 		"pixl-unit": "^1.0.10"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Cronicle",
-	"version": "0.8.62",
+	"version": "0.8.63",
 	"description": "A simple, distributed task scheduler and runner with a web based UI.",
 	"author": "Joseph Huckaby <jhuckaby@gmail.com>",
 	"homepage": "https://github.com/jhuckaby/Cronicle",

--- a/sample_conf/config.json
+++ b/sample_conf/config.json
@@ -30,8 +30,7 @@
 	"server_comm_use_hostnames": false,
 	"web_direct_connect": false,
 	"web_socket_use_hostnames": false,
-	"worker_connect_proto": "http",
-	"worker_connect_port": 3012,
+	"worker_proxy_logs": false,
 	
 	"job_memory_max": 1073741824,
 	"job_memory_sustain": 0,

--- a/sample_conf/config.json
+++ b/sample_conf/config.json
@@ -30,6 +30,8 @@
 	"server_comm_use_hostnames": false,
 	"web_direct_connect": false,
 	"web_socket_use_hostnames": false,
+	"worker_connect_proto": "http",
+	"worker_connect_port": 3012,
 	"worker_proxy_logs": false,
 	
 	"job_memory_max": 1073741824,

--- a/sample_conf/config.json
+++ b/sample_conf/config.json
@@ -30,6 +30,8 @@
 	"server_comm_use_hostnames": false,
 	"web_direct_connect": false,
 	"web_socket_use_hostnames": false,
+	"worker_connect_proto": "http",
+	"worker_connect_port": 3012,
 	
 	"job_memory_max": 1073741824,
 	"job_memory_sustain": 0,

--- a/sample_conf/config.json
+++ b/sample_conf/config.json
@@ -30,9 +30,7 @@
 	"server_comm_use_hostnames": false,
 	"web_direct_connect": false,
 	"web_socket_use_hostnames": false,
-	"worker_connect_proto": "http",
-	"worker_connect_port": 3012,
-	"worker_proxy_logs": false,
+    "live_log_poll_interval": 1000,
 	
 	"job_memory_max": 1073741824,
 	"job_memory_sustain": 0,


### PR DESCRIPTION
Being able to connect directly from your browser to the worker nodes in a multi server setup can be complex in many environments where corporate security is high or network flows are complex.  Instead it can be beneficial to be able to retrieve live logs by proxying the requests through the master.

This PR implements a pull through mechanism that allows the browser to request a live log from the master.  The master will then make another request to the worker node to get the last X lines from the workers log file.  Those lines are then sent back to the users browser.

A de-dupping of the log lines is also applied at the browser since slow scripts or short logs in general can cause duplication in the log lines being returned when requesting the last X lines from a log file.

Also a big thanks to @mikeTWC1984 for pointing me at his [previous effort](https://github.com/jhuckaby/Cronicle/issues/391#issuecomment-822600803) put in to make this work as it was the basis for this updated version.