### PR TITLE
Fix terminate orphans processes running from the shell-plugin

### DIFF
--- a/bin/shell-plugin.js
+++ b/bin/shell-plugin.js
@@ -9,6 +9,7 @@ var fs = require('fs');
 var os = require('os');
 var cp = require('child_process');
 var path = require('path');
+var send_sig = require('tree-kill');
 var JSONStream = require('pixl-json-stream');
 var Tools = require('pixl-tools');
 
@@ -132,11 +133,11 @@ stream.on('json', function(job) {
 		kill_timer = setTimeout( function() {
 			// child didn't die, kill with prejudice
 			console.log("Child did not exit, killing harder: " + child.pid);
-			child.kill('SIGKILL');
+			send_sig(child.pid, 'SIGKILL');
 		}, 9 * 1000 );
 		
 		// try killing nicely first
-		child.kill('SIGTERM');
+		send_sig(child.pid, 'SIGTERM');
 	} );
 	
 } ); // stream

--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
 		"pixl-server-storage": "^3.0.21",
 		"pixl-server-web": "^1.3.8",
 		"pixl-server-api": "^1.0.2",
-		"pixl-server-user": "^1.0.9"
+		"pixl-server-user": "^1.0.9",
+		"tree-kill": "^1.2.2"
 	},
 	"devDependencies": {
 		"pixl-unit": "^1.0.12"


### PR DESCRIPTION
Patch with fix terminating tree of processes running from the shell-plugin. It's reached using module [tree-kill](https://www.npmjs.com/package/tree-kill).

Related to #248