### PR TITLE
Fix for newly added remote_server_port

### DIFF
--- a/lib/comm.js
+++ b/lib/comm.js
@@ -66,7 +66,7 @@ module.exports = Class.create({
 	connectToSlave: function(slave) {
 		// establish communication with slave via socket.io
 		var self = this;
-		var port = this.config.get('remote_server_port') || this.web.config.get('http_port');
+		var port = this.server.config.get('remote_server_port') || this.web.config.get('http_port');
 		
 		var url = '';
 		if (this.server.config.get('server_comm_use_hostnames')) {

--- a/sample_conf/config.json
+++ b/sample_conf/config.json
@@ -26,6 +26,7 @@
 	"universal_web_hook": "",
 	"track_manual_jobs": false,
 	"max_jobs": 0,
+	"remote_server_port": 3012,
 	
 	"server_comm_use_hostnames": false,
 	"web_direct_connect": false,


### PR DESCRIPTION
Simple fix as the config pull was missing ".server"

Added field to sample config.json as well.