### PR TITLE
Add EOL error message

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -612,7 +612,7 @@ module.exports = Class.create({
 			try {
 				child = cp.spawn( child_cmd, child_args, child_opts );
 				if (!child || !child.pid || !child.stdin || !child.stdout) {
-					throw new Error("Child process failed to spawn (Check executable location and permissions?)");
+					throw new Error("Child process failed to spawn (Check executable location, permissions, or EOL format?)");
 				}
 			}
 			catch (err) {


### PR DESCRIPTION
Add message about EOL format that prevents confusion from generic message "Child process failed to spawn (Check executable location and permissions?)".